### PR TITLE
feat: motion component

### DIFF
--- a/src/hooks/use-previous-value-effect.ts
+++ b/src/hooks/use-previous-value-effect.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const usePreviousValueEffect = (f: PreviousValueEffect, deps?: React.DependencyList) => {
+    const previousDeps = React.useRef(deps);
+    
+    React.useEffect(() => {
+        const cleanup = f(previousDeps.current, deps);
+
+        return cleanup;
+    }, [f, deps])
+}
+
+export type PreviousValueEffect = (from: React.DependencyList | undefined, to: React.DependencyList | undefined) => void | (() => void);

--- a/src/hooks/use-previous-value-effect.ts
+++ b/src/hooks/use-previous-value-effect.ts
@@ -7,7 +7,8 @@ export const usePreviousValueEffect = (f: PreviousValueEffect, deps?: React.Depe
         const cleanup = f(previousDeps.current, deps);
 
         return cleanup;
-    }, [f, deps])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps ? [...deps] : deps);
 }
 
 export type PreviousValueEffect = (from: React.DependencyList | undefined, to: React.DependencyList | undefined) => void | (() => void);

--- a/src/hooks/use-previous-value-effect.ts
+++ b/src/hooks/use-previous-value-effect.ts
@@ -8,7 +8,7 @@ export const usePreviousValueEffect = (f: PreviousValueEffect, deps?: React.Depe
 
         return cleanup;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, deps ? [...deps] : deps);
+    }, deps);
 }
 
 export type PreviousValueEffect = (from: React.DependencyList | undefined, to: React.DependencyList | undefined) => void | (() => void);

--- a/src/utils/resolve-in-sequence.ts
+++ b/src/utils/resolve-in-sequence.ts
@@ -1,0 +1,2 @@
+export const resolveInSequence = (promises: Promise<unknown>[]) => 
+    promises.reduce((sequence, promise) => sequence.then(() => promise), Promise.resolve());


### PR DESCRIPTION
Previous implementation was all wrong

We want:
- `animate` as these values change between renders, should transition between
   - what if we have keys in `final` which are not in `initial`?
- `initial` when component first shows these animations should trigger
- `exit` when component is removed from DOM these should show
   - put the behaviour in `Presence` and wrap in a div
   - expose an imperative handler and trigger exit animations from `Presence` and when all exit animations complete update the rendered children (not so easy to get things to work since we have generics and the proxy and need two `forwardRef`, think we won't need 2 forward refs so long as the end result is forwarded)
   - `Presence` also has `exitBeforeEnter`: wait for the exiting element to finish animating out before animating in the next one so we need to capture the change to `children` anyway

