### PR TITLE
fix: presence renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,18 @@ import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
 import { Motion } from "./Motion";
+import { Presence } from "./Presence";
 
 function App() {
 	const [count, setCount] = useState(0);
+	const [show, setShow] = useState(false);
 
 	const animateOptions = { opacity: count / 5 };
+
+	setInterval(() => {
+		console.log("Here!");
+		setShow(show => !show);
+	}, 1000);
 	return (
 		<>
 			<div>
@@ -20,16 +27,13 @@ function App() {
 			</div>
 			<h1>Vite + React</h1>
 			<div className="card">
-				<Motion.button
-					key="test"
-					animate={animateOptions}
-					initial={{ opacity: 0.1 }}
-					onClick={() => setCount(count => count + 1)}>
-					count is {count}
-				</Motion.button>
-				<Motion.div initial={{ opacity: 0.1 }}>
-					<TestButton />
-				</Motion.div>
+				<Presence>
+					{show && (
+						<Motion.div key="test" initial={{ opacity: 0.1 }}>
+							<TestButton />
+						</Motion.div>
+					)}
+				</Presence>
 				<p>
 					Edit <code>src/App.tsx</code> and save to test HMR
 				</p>


### PR DESCRIPTION
Issue: #3 

- Same problem as before, parent state updates, everything is torn down so we lose previous props in `Presence` and we cannot determine elements to exit (I think, unsure)

Needs to be reworked, we cannot rely on effects, state to determine children to render or clone element (because we lose state when we do this) ??

- initial render: display children filtered, `renderedChildren` = `initialChildren`
  - before when `children` was undefined, `React.Children.toArray` did not always produce an array
- keep track of rendered children
- just trigger exit animation and leave it in the DOM (how to get access to the instance to trigger???)
  - when we clone element, we have:
     - `<Motion.button onClick={...} />` where the state is in the parent and preserved if we clone
     - `<Motion.div>{children}</Motion.div>` where state is in `Motion`'s children so if we clone `Motion` we lose the state in `children`, maybe preserving children will work?
- pending children splice beside exiting, same as before and excess appended